### PR TITLE
Added field migration for Image, Set and collectionlinkselect

### DIFF
--- a/cockpit-cms-Migrate/Helper/Convert.php
+++ b/cockpit-cms-Migrate/Helper/Convert.php
@@ -561,7 +561,7 @@ class Convert extends \Lime\Helper {
         unset($entry['_by']);
 
         // set default state to "published"
-        $entry['_state'] = $entry['_state'] ?? 0;
+        $entry['_state'] = $entry['_state'] ?? 1;
 
         // TODO: transform assets
 

--- a/cockpit-cms-Migrate/Helper/TransformFields.php
+++ b/cockpit-cms-Migrate/Helper/TransformFields.php
@@ -58,6 +58,39 @@ class TransformFields extends \Lime\Helper {
         return $field;
     }
 
+    public function _image(array $field): array {
+        $field['type'] = 'asset';
+        $options = fixToArray($field['options'] ?? []);
+        $field['opts'] = $options;
+        return $field;
+    }
+
+    public function _set(array $field): array {
+        $field['opts'] = fixToArray($field['opts'] ?? []);
+        $transformedField = $this->convertModelFields($field['options']['fields']);
+        $field['opts']['fields'] = $transformedField;
+        return $field;
+    }
+
+    public function _collectionlinkselect(array $field): array {
+        $field['type'] = 'contentItemLink';
+
+        $options = fixToArray($field['options'] ?? []);
+
+        $link = $options['link'] ?? null;
+        $display = $options['display'] ?? null;
+
+        $transformedField = [
+            'link' => $link,
+            'filter' => null,
+            'display' => $display ? "\${data.$display}" : null,
+        ];
+
+        $field['opts'] = $transformedField;
+
+        return $field;
+    }
+
     public function _select(array $field): array {
 
         $field['type'] = 'select';
@@ -233,8 +266,6 @@ class TransformFields extends \Lime\Helper {
      * Transform gallery to asset (multiple)
      */
     public function galleryToAssetMultiple($entry, $field) {
-
-        
 
         return $entry;
 

--- a/cockpit-cms-Migrate/views/v2/index.php
+++ b/cockpit-cms-Migrate/views/v2/index.php
@@ -5,10 +5,18 @@
         <kiss-container class="kiss-margin-large">
 
             <ul class="kiss-breadcrumbs">
-                <li><a href="<?=$this->route('/migrate')?>"><?=t('Migrate')?></a></li>
+                <li><a href="<?= $this->route('/migrate') ?>"><?= t('Migrate') ?></a></li>
             </ul>
 
-            <a href="<?=$this->route('/migrate/migrate')?>" target="_blank"><?=t('Migrate (dry-run)')?></a>
+            <p>
+                <a href="<?= $this->route('/migrate/migrate') ?>" target="_blank"><?= t('Migrate (dry-run)') ?></a>
+            </p>
+            <p>
+                <a href="<?= $this->route('/migrate/migrate/all/write') ?>" target="_blank"><?= t('Migrate') ?></a>
+            </p>
+            <p>
+                <a href="<?= $this->route('/migrate/deleteV1stuff') ?>" target="_blank"><?= t('Delete v1 files') ?></a>
+            </p>
 
         </kiss-container>
 
@@ -20,11 +28,9 @@
 
     <script type="module">
 
-        export default {
-        }
+        export default {}
     </script>
 </vue-view>
-
 
 
 <?php //$this->start('app-side-panel') ?>


### PR DESCRIPTION
I added field migrations for
* Image to Asset fields,
* collectionlinkselect to contentItemLink fields and
* translation of the old Set fields to the new JSON syntax.

Furthermore I fixed the part of the code which was supposed to set all migrated contents to "published" and I added the options "Migrate" and "Delete v1 files" to the Migration addon UI for Cockpit v2.